### PR TITLE
Handle goose logging output

### DIFF
--- a/leie/leie/model.py
+++ b/leie/leie/model.py
@@ -165,9 +165,9 @@ DROP TABLE reinstatement;
             out, err = p.communicate()
             out = out.decode("utf-8")
             err = err.decode("utf-8")
-            if err != '':
+            if p.returncode != 0:
                 sys.stderr.write("%s\n%s" % (out, err))
-                raise subprocess.CalledProcessError(0, cmd, out+err)
+                raise subprocess.CalledProcessError(p.returncode, cmd, out+err)
             return out
 
     def up(self, migration):


### PR DESCRIPTION
Goose now logs a notice to stderr when there are no further migrations to run:

    goose: no migrations to run. current version: 20170606100001

Instead of failing the ETL process in the event of any output on stderr, test the return code and stop if it is nonzero.

Resolves #7 LEIE ETL fails on recent versions of goose